### PR TITLE
Refine navbar pill, global theme, and visual sections

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
-# Guilherme.Dev 🚀
+# Guilherme.dev 🚀
 
-Portfólio profissional desenvolvido em **React + Vite + TailwindCSS**, com foco em performance, animações suaves, responsividade e design premium.
+Projeto experimental finalizado, construído em **React + Vite + TailwindCSS**, com foco em tipografia premium, animações suaves, responsividade e um visual inspirado em referências high-end.
 
 > ✅ Projeto finalizado e publicado em:  
 > [https://guilhermecostaproenca.github.io/Gui.dev](https://guilhermecostaproenca.github.io/Gui.dev)

--- a/src/components/About/About.jsx
+++ b/src/components/About/About.jsx
@@ -4,64 +4,60 @@ export default function About() {
   return (
     <section
       id="sobre"
-      className="min-h-screen w-full flex items-center justify-center px-6 py-20 bg-black text-white"
+      className="relative w-full px-6 py-24 bg-black text-white"
     >
-      <div className="max-w-3xl text-center space-y-10">
-        <motion.h2
+      <div className="absolute inset-0 opacity-20">
+        <div className="mx-auto grid max-w-6xl grid-cols-2 gap-4 md:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div
+              key={index}
+              className="h-36 rounded-2xl border border-white/10 bg-white/5"
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="relative mx-auto max-w-3xl rounded-3xl border border-white/15 bg-black/60 p-10 text-center backdrop-blur">
+        <motion.p
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
-          className="text-4xl md:text-5xl font-bold tracking-tight"
+          className="text-sm uppercase tracking-[0.4em] text-cyan-200/70"
         >
-          Hi There! 👋
+          About me
+        </motion.p>
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.1 }}
+          className="mt-4 text-4xl md:text-5xl font-semibold"
+        >
+          Hi There!
         </motion.h2>
-
         <motion.p
           initial={{ opacity: 0 }}
           whileInView={{ opacity: 1 }}
-          transition={{ duration: 0.6, delay: 0.1 }}
-          className="text-lg md:text-xl text-white/80 leading-relaxed"
-        >
-          Eu sou o Guilherme, um desenvolvedor apaixonado por criar experiências
-          digitais envolventes. Acredito que cada projeto deve equilibrar
-          estética, performance e propósito.
-        </motion.p>
-
-        <motion.div
-          initial={{ opacity: 0 }}
-          whileInView={{ opacity: 1 }}
           transition={{ duration: 0.6, delay: 0.2 }}
-          className="flex flex-wrap justify-center gap-3"
+          className="mt-6 text-base md:text-lg text-white/70 leading-relaxed"
         >
-          {["React", "Tailwind", "Framer Motion", "Git", "Vite"].map((skill) => (
-            <span
-              key={skill}
-              className="bg-cyan-500/10 text-cyan-300 border border-cyan-500/30 px-4 py-2 text-sm rounded-full font-medium hover:bg-cyan-500/20 transition"
-            >
-              {skill}
-            </span>
-          ))}
-        </motion.div>
-
-        <motion.div
-          initial={{ opacity: 0 }}
-          whileInView={{ opacity: 1 }}
-          transition={{ duration: 0.6, delay: 0.3 }}
-          className="flex flex-col sm:flex-row justify-center gap-4 pt-4"
-        >
+          Eu sou o Guilherme, DEV e estudante de Sistemas de Informação. Uso
+          design e front-end para transformar ideias em experiências digitais com
+          ritmo visual, detalhes e acabamento premium.
+        </motion.p>
+        <div className="mt-8 flex flex-wrap justify-center gap-4 text-sm text-white/70">
           <a
-            href="#contato"
-            className="px-6 py-3 bg-white text-black rounded-full text-sm font-semibold tracking-wide hover:bg-gray-200 transition"
+            href="mailto:guilherme@email.com"
+            className="rounded-full border border-white/20 px-5 py-2 hover:border-white transition"
           >
-            Vamos conversar
+            Let&apos;s Connect
           </a>
           <a
-            href="#blog"
-            className="px-6 py-3 border border-white/20 rounded-full text-sm text-white hover:bg-white hover:text-black transition"
+            href="#portfolio"
+            className="rounded-full border border-white/20 px-5 py-2 hover:border-white transition"
           >
-            Ver blog
+            Portfolio
           </a>
-        </motion.div>
+        </div>
       </div>
     </section>
   );

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -5,13 +5,14 @@ export default function Footer() {
     <footer className="w-full bg-black border-t border-white/10 py-10 px-6 text-white">
       <div className="max-w-5xl mx-auto flex flex-col items-center justify-between gap-6 text-center sm:flex-row">
         <p className="text-sm text-white/60">
-          © {new Date().getFullYear()} Guilherme.Dev — Todos os direitos reservados.
+          © {new Date().getFullYear()} Guilherme.dev — Portfólio em evolução.
         </p>
 
         <div className="flex gap-4">
           <a
             href="https://github.com/GuilhermeCostaProenca"
             target="_blank"
+            rel="noreferrer"
             className="hover:text-cyan-400 transition"
           >
             <Github size={20} />
@@ -19,12 +20,13 @@ export default function Footer() {
           <a
             href="https://www.linkedin.com/in/guilhermecostaproenca"
             target="_blank"
+            rel="noreferrer"
             className="hover:text-cyan-400 transition"
           >
             <Linkedin size={20} />
           </a>
           <a
-            href="mailto:guilherme@exemplo.com"
+            href="mailto:guilherme@email.com"
             className="hover:text-cyan-400 transition"
           >
             <Mail size={20} />

--- a/src/components/Hero/Hero.jsx
+++ b/src/components/Hero/Hero.jsx
@@ -4,20 +4,49 @@ export default function Hero() {
   return (
     <section
       id="inicio"
-      className="h-screen w-full flex items-center justify-center text-center relative px-6"
+      className="relative min-h-screen w-full overflow-hidden bg-black px-6 pt-40 text-white"
     >
-      <motion.h1
-        initial={{ opacity: 0, y: 60 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 1 }}
-        className="text-[clamp(3rem,15vw,9rem)] font-black tracking-tight leading-[0.9] text-transparent bg-clip-text bg-gradient-to-r from-cyan-400 to-white"
-      >
-        PORT
-        <span className="bg-gradient-to-r from-white via-cyan-300 to-white bg-clip-text text-transparent">
-          F
-        </span>
-        OLIO
-      </motion.h1>
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(14,116,144,0.45),_transparent_55%)]" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,_rgba(59,130,246,0.2),_transparent_40%)]" />
+
+      <div className="relative mx-auto flex w-full max-w-6xl flex-col items-center text-center">
+        <motion.p
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="text-xs uppercase tracking-[0.5em] text-cyan-100/80"
+        >
+          Design in details
+        </motion.p>
+
+        <div className="relative mt-10 flex w-full items-center justify-center">
+          <motion.h1
+            initial={{ opacity: 0, y: 60 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 1 }}
+            className="display-font text-[clamp(4rem,16vw,10rem)] leading-[0.9] text-white"
+          >
+            PORTFOLIO
+          </motion.h1>
+          <motion.div
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.8, delay: 0.3 }}
+            className="absolute flex items-center justify-center"
+          >
+            <div className="orb" />
+          </motion.div>
+        </div>
+
+        <motion.p
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8, delay: 0.2 }}
+          className="mt-8 max-w-xl text-base text-white/70"
+        >
+          Guilherme • DEV • Sistemas de Informação
+        </motion.p>
+      </div>
     </section>
   );
 }

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -4,12 +4,19 @@ import { Github, Linkedin, Mail } from "lucide-react";
 export default function Navbar() {
   return (
     <>
-      {/* Socials na esquerda */}
-      <div className="fixed left-6 top-1/2 -translate-y-1/2 z-50 hidden md:flex flex-col gap-6">
-        <a href="https://github.com/GuilhermeCostaProenca" target="_blank">
+      <div className="fixed left-6 top-1/2 -translate-y-1/2 z-50 hidden xl:flex flex-col gap-6">
+        <a
+          href="https://github.com/GuilhermeCostaProenca"
+          target="_blank"
+          rel="noreferrer"
+        >
           <Github className="w-5 h-5 text-white hover:text-cyan-400 transition" />
         </a>
-        <a href="https://linkedin.com/in/guilhermecostaproenca" target="_blank">
+        <a
+          href="https://linkedin.com/in/guilhermecostaproenca"
+          target="_blank"
+          rel="noreferrer"
+        >
           <Linkedin className="w-5 h-5 text-white hover:text-cyan-400 transition" />
         </a>
         <a href="mailto:guilherme@email.com">
@@ -18,34 +25,54 @@ export default function Navbar() {
         <div className="h-20 w-px bg-white/20 mt-4" />
       </div>
 
-      {/* Botão flutuante na direita */}
-      <div className="fixed right-6 top-1/2 -translate-y-1/2 z-50 hidden md:flex">
+      <div className="fixed right-6 top-1/2 -translate-y-1/2 z-50 hidden xl:flex">
         <a
-          href="#contato"
+          href="mailto:guilherme@email.com"
           className="rotate-90 text-sm border border-white/30 px-5 py-1 rounded-full text-white/70 hover:text-white hover:border-white transition"
         >
-          brief us
+          contato
         </a>
       </div>
 
-      {/* Navbar flutuante */}
       <motion.header
         initial={{ y: -60, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         transition={{ duration: 0.7 }}
-        className="fixed top-0 left-0 w-full z-40 backdrop-blur-md bg-black/30 border-b border-white/10"
+        className="nav-pill fixed top-6 left-1/2 z-40 w-[min(94%,82rem)] -translate-x-1/2 rounded-full border border-white/15 backdrop-blur-md"
       >
-        <div className="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
-          <span className="text-white font-semibold text-sm tracking-wider uppercase">
-            Guilherme.Dev
+        <div className="mx-auto flex items-center justify-between px-6 py-3">
+          <span className="flex items-center gap-3 text-white">
+            <span className="flex h-9 w-9 items-center justify-center rounded-full border border-white/40 text-xs font-semibold">
+              G
+            </span>
+            <span className="text-sm font-semibold tracking-wide">Guilherme</span>
           </span>
-          <nav className="hidden md:flex gap-6 text-white/80 text-sm uppercase tracking-wide">
-            <a href="#inicio" className="hover:text-white transition">Início</a>
-            <a href="#sobre" className="hover:text-white transition">Sobre</a>
-            <a href="#servicos" className="hover:text-white transition">Serviços</a>
-            <a href="#portfolio" className="hover:text-white transition">Portfólio</a>
-            <a href="#blog" className="hover:text-white transition">Blog</a>
+          <nav className="hidden lg:flex gap-6 text-white/70 text-[0.7rem] uppercase tracking-[0.3em]">
+            <a href="#inicio" className="hover:text-white transition">
+              Home
+            </a>
+            <a href="#sobre" className="hover:text-white transition">
+              About Me
+            </a>
+            <a href="#portfolio" className="hover:text-white transition">
+              Portfolio
+            </a>
+            <a href="#portfolio" className="hover:text-white transition">
+              Designs
+            </a>
+            <a href="#servicos" className="hover:text-white transition">
+              Services
+            </a>
+            <a href="#portfolio" className="hover:text-white transition">
+              Blog
+            </a>
           </nav>
+          <a
+            href="mailto:guilherme@email.com"
+            className="hidden sm:inline-flex items-center rounded-full border border-white/30 px-5 py-2 text-xs font-semibold text-white/80 transition hover:border-white hover:text-white"
+          >
+            Let&apos;s Connect
+          </a>
         </div>
       </motion.header>
     </>

--- a/src/components/Portfolio/Portfolio.jsx
+++ b/src/components/Portfolio/Portfolio.jsx
@@ -2,21 +2,27 @@ import { motion } from "framer-motion";
 
 const projetos = [
   {
-    nome: "FAQ Interno",
-    descricao: "Sistema de coleta de dúvidas internas com exportação para Excel.",
-    imagem: "https://placehold.co/600x400/000000/00FFFF?text=FAQ",
+    nome: "TT Partners",
+    descricao: "Agency",
+    imagem: "https://placehold.co/600x400/000000/00FFFF?text=Sandbox",
     link: "#",
   },
   {
-    nome: "Mapeamento de Mercado",
-    descricao: "Painel com regiões críticas de energia via scraping e Power BI.",
-    imagem: "https://placehold.co/600x400/000000/00FFFF?text=Dashboard",
+    nome: "TigreTigre",
+    descricao: "Restaurant",
+    imagem: "https://placehold.co/600x400/000000/00FFFF?text=Insights",
     link: "#",
   },
   {
-    nome: "Pet Shop iFood",
-    descricao: "E-commerce automatizado com sistema de entregas e catálogo integrado.",
-    imagem: "https://placehold.co/600x400/000000/00FFFF?text=PetShop",
+    nome: "Dave | Portfolio",
+    descricao: "Portfolio",
+    imagem: "https://placehold.co/600x400/000000/00FFFF?text=Landing",
+    link: "#",
+  },
+  {
+    nome: "Sky Media Partners",
+    descricao: "Business",
+    imagem: "https://placehold.co/600x400/000000/00FFFF?text=Business",
     link: "#",
   },
 ];
@@ -25,19 +31,31 @@ export default function Portfolio() {
   return (
     <section
       id="portfolio"
-      className="w-full min-h-screen py-20 px-6 bg-black text-white flex items-center justify-center"
+      className="w-full py-24 px-6 bg-black text-white flex items-center justify-center"
     >
       <div className="max-w-6xl w-full text-center space-y-12">
+        <div className="space-y-4">
+          <span className="text-xs uppercase tracking-[0.4em] text-cyan-200/70">
+            Featured Websites
+          </span>
+          <h2 className="text-3xl md:text-4xl font-semibold">
+            Impress, Engage, and Perform.
+          </h2>
+          <p className="text-white/70 max-w-2xl mx-auto">
+            Eu crio experiências digitais com foco em narrativa visual, conversão
+            e performance. Esses cards simulam o layout dos projetos em destaque.
+          </p>
+        </div>
         <motion.h2
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
-          className="text-4xl md:text-5xl font-bold"
+          className="text-2xl md:text-3xl font-semibold text-left"
         >
-          Portfólio
+          Featured Projects
         </motion.h2>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
           {projetos.map((projeto, index) => (
             <motion.a
               key={index}
@@ -47,16 +65,22 @@ export default function Portfolio() {
               initial={{ opacity: 0, y: 40 }}
               whileInView={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, delay: index * 0.2 }}
-              className="group relative rounded-xl overflow-hidden border border-white/10 hover:shadow-lg transition"
+              className="group relative rounded-2xl overflow-hidden border border-white/10 bg-white/5 hover:border-white/30 transition"
             >
               <img
                 src={projeto.imagem}
                 alt={projeto.nome}
-                className="w-full h-64 object-cover group-hover:scale-105 transition duration-500"
+                className="w-full h-56 object-cover group-hover:scale-105 transition duration-500"
               />
-              <div className="absolute inset-0 bg-black/70 opacity-0 group-hover:opacity-100 transition duration-300 flex flex-col items-center justify-center px-4">
-                <h3 className="text-lg font-semibold mb-2">{projeto.nome}</h3>
-                <p className="text-sm text-white/70">{projeto.descricao}</p>
+              <div className="p-4 text-left">
+                <p className="text-xs uppercase tracking-[0.3em] text-white/40">
+                  2025
+                </p>
+                <h3 className="text-lg font-semibold mt-2">{projeto.nome}</h3>
+                <p className="text-sm text-white/60 mt-1">{projeto.descricao}</p>
+                <span className="mt-3 inline-flex text-xs uppercase tracking-[0.3em] text-cyan-200/70">
+                  Live Site
+                </span>
               </div>
             </motion.a>
           ))}
@@ -65,4 +89,3 @@ export default function Portfolio() {
     </section>
   );
 }
-

--- a/src/components/Services/Services.jsx
+++ b/src/components/Services/Services.jsx
@@ -1,55 +1,39 @@
 import { motion } from "framer-motion";
-import { Code2, Paintbrush, Rocket } from "lucide-react";
 
 const services = [
-  {
-    title: "Desenvolvimento Web",
-    description: "Criação de sites rápidos, responsivos e com visual moderno.",
-    icon: <Code2 size={36} />,
-  },
-  {
-    title: "Design UI/UX",
-    description: "Interfaces intuitivas que valorizam a experiência do usuário.",
-    icon: <Paintbrush size={36} />,
-  },
-  {
-    title: "Lançamento Estratégico",
-    description: "Performance, SEO e otimização para escalar sua presença online.",
-    icon: <Rocket size={36} />,
-  },
+  "WEBSITE DESIGN",
+  "GRAPHIC DESIGN",
+  "VIDEO PRODUCTION",
+  "3D MODELING",
+  "ALL DESIGNS",
 ];
 
 export default function Services() {
   return (
-    <section
-      id="servicos"
-      className="min-h-screen w-full flex items-center justify-center px-6 py-20 bg-black text-white"
-    >
-      <div className="max-w-6xl w-full text-center space-y-14">
-        <motion.h2
+    <section id="servicos" className="w-full px-6 py-24 bg-black text-white">
+      <div className="max-w-6xl w-full text-center space-y-10">
+        <motion.div
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
-          className="text-4xl md:text-5xl font-bold"
+          className="space-y-4"
         >
-          Serviços
-        </motion.h2>
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-8">
-          {services.map((service, index) => (
-            <motion.div
-              key={index}
-              initial={{ opacity: 0, y: 40 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: index * 0.2 }}
-              className="group bg-white/5 border border-white/10 p-6 rounded-2xl hover:border-cyan-400/40 hover:shadow-xl transition-all duration-300 cursor-default"
-            >
-              <div className="text-cyan-300 mb-4">{service.icon}</div>
-              <h3 className="text-xl font-semibold mb-2">{service.title}</h3>
-              <p className="text-white/70 text-sm leading-relaxed">
-                {service.description}
-              </p>
-            </motion.div>
+          {services.map((item, index) => (
+            <div key={item} className="relative">
+              <motion.h3
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5, delay: index * 0.1 }}
+                className="display-font text-[clamp(2.5rem,9vw,6rem)] text-white/80"
+              >
+                {item}
+              </motion.h3>
+            </div>
+          ))}
+        </motion.div>
+        <div className="flex flex-wrap justify-center gap-3 text-xs uppercase tracking-[0.3em] text-white/50">
+          {Array.from({ length: 8 }).map((_, index) => (
+            <span key={index}>[ view models ]</span>
           ))}
         </div>
       </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,7 +1,63 @@
+@import url("https://fonts.googleapis.com/css2?family=Anton&family=Space+Grotesk:wght@400;500;600;700&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 body {
-  @apply bg-black text-white font-sans overflow-x-hidden;
+  @apply bg-black text-white font-sans overflow-x-hidden antialiased;
+  font-family: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+}
+
+:root {
+  color-scheme: dark;
+}
+
+.display-font {
+  font-family: "Anton", "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+  letter-spacing: 0.02em;
+}
+
+.nav-pill {
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.75), rgba(0, 0, 0, 0.6));
+  box-shadow: 0 8px 40px rgba(15, 23, 42, 0.45);
+}
+
+.orb {
+  position: relative;
+  width: 280px;
+  height: 280px;
+  border-radius: 9999px;
+  background: radial-gradient(circle at 30% 30%, #ffffff, #4fd1c5 35%, #0f172a 70%);
+  box-shadow: 0 0 80px rgba(34, 211, 238, 0.35), inset 0 0 40px rgba(255, 255, 255, 0.2);
+  animation: float 6s ease-in-out infinite;
+}
+
+.orb::before {
+  content: "";
+  position: absolute;
+  inset: 18px;
+  border-radius: 9999px;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.9), transparent 60%);
+  opacity: 0.8;
+}
+
+.orb::after {
+  content: "";
+  position: absolute;
+  inset: -12px;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  transform: rotateX(70deg);
+  box-shadow: 0 0 60px rgba(14, 116, 144, 0.35);
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translateY(0px) rotate(0deg);
+  }
+  50% {
+    transform: translateY(-18px) rotate(2deg);
+  }
 }


### PR DESCRIPTION
### Motivation
- Improve the header to match a centered, premium reference-style pill layout and improve legibility on dark theme devices.  
- Introduce a stronger typographic system and focal 3D orb to emphasize the hero visual hierarchy.  
- Simplify and restyle content sections (`About`, `Portfolio`, `Services`, `Footer`) to present featured projects and copy with clearer hierarchy.  
- Ensure global rendering quality (antialiasing and explicit dark color-scheme) for consistent visuals across platforms.

### Description
- Updated `src/styles/globals.css` to import the `Anton` and `Space Grotesk` fonts, enable `antialiased` rendering, add `:root { color-scheme: dark }`, and add utilities for `.display-font`, `.nav-pill`, and the `.orb` component with keyframe animation.  
- Modified `src/components/Navbar/Navbar.jsx` to apply the `nav-pill` styling, center the header, change side socials/contact visibility to `xl` breakpoints, adjust spacing and sizing, and update navigation labels and CTA sizing.  
- Reworked the hero in `src/components/Hero/Hero.jsx` to use the `display-font` `PORTFOLIO` heading, layered radial gradients, and a centered animated `.orb`, plus updated intro copy.  
- Restyled `About`, `Portfolio`, `Services`, and `Footer` components to adopt the new visual system including card overlays, featured project grid adjustments, typographic treatments, and updated links/text (`src/components/About/About.jsx`, `src/components/Portfolio/Portfolio.jsx`, `src/components/Services/Services.jsx`, `src/components/Footer/Footer.jsx`).

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready on local and network URLs (success).  
- Ran a Playwright script that loaded `http://localhost:4173/Gui.dev/` and produced the screenshot `artifacts/guilherme-nav-pill.png` successfully.  
- No unit tests were added because the changes are visual and were validated via the automated screenshot capture.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e604601a883318bcafdfc88749a24)