### PR TITLE
Enhance UI interactions, mobile menu, hero parallax, custom cursor and accessibility

### DIFF
--- a/src/components/About/About.jsx
+++ b/src/components/About/About.jsx
@@ -7,29 +7,49 @@ export default function About() {
         <motion.div
           initial={{ opacity: 0, y: 40 }}
           whileInView={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.7 }}
+          transition={{ duration: 0.7, ease: "easeOut" }}
           viewport={{ once: true }}
           className="glass-panel rounded-3xl px-8 py-10 text-center md:px-14 md:py-16"
         >
-          <span className="text-xs uppercase tracking-[0.4em] text-cyan-200/70">
+          <motion.span
+            initial={{ opacity: 0, y: 15 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.1 }}
+            viewport={{ once: true }}
+            className="text-xs uppercase tracking-[0.4em] text-cyan-200/70"
+          >
             Sobre mim
-          </span>
-          <h2 className="mt-4 text-3xl font-semibold md:text-4xl">Hi There!</h2>
-          <p className="mt-4 text-sm text-white/70 md:text-base">
+          </motion.span>
+          <motion.h2
+            initial={{ opacity: 0, y: 15 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.2 }}
+            viewport={{ once: true }}
+            className="mt-4 text-3xl font-semibold md:text-4xl"
+          >
+            Olá!
+          </motion.h2>
+          <motion.p
+            initial={{ opacity: 0, y: 15 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.3 }}
+            viewport={{ once: true }}
+            className="mt-4 text-sm text-white/70 md:text-base"
+          >
             Sou Guilherme, designer e desenvolvedor focado em{" "}
             <span className="highlight-word">interfaces impactantes</span>. Combino
             <span className="highlight-word"> tipografia</span>,{" "}
             <span className="highlight-word">composição</span> e{" "}
             <span className="highlight-word">cor</span> para entregar experiências
             que elevam a presença da sua marca.
-          </p>
+          </motion.p>
           <div className="mt-8 flex flex-wrap justify-center gap-4">
             <a
               href="#contato"
               data-cursor="large"
               className="rounded-full border border-white/20 px-6 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:border-cyan-200/80 hover:text-cyan-200"
             >
-              Let&apos;s Connect
+              Vamos conversar
             </a>
             <a
               href="#portfolio"

--- a/src/components/CursorFollower/CursorFollower.jsx
+++ b/src/components/CursorFollower/CursorFollower.jsx
@@ -46,6 +46,18 @@ export default function CursorFollower() {
     };
 
     const setActiveState = (event) => {
+      const inputTarget = event.target.closest(
+        "input, textarea, select, [contenteditable='true']"
+      );
+      if (inputTarget) {
+        dot.classList.add("is-hidden");
+        ring.classList.add("is-hidden");
+        return;
+      }
+
+      dot.classList.remove("is-hidden");
+      ring.classList.remove("is-hidden");
+
       const target = event.target.closest("[data-cursor='large']");
       if (target) {
         dot.classList.add("is-active");
@@ -56,13 +68,27 @@ export default function CursorFollower() {
       }
     };
 
+    const handlePointerDown = () => {
+      dot.classList.add("is-clicked");
+      ring.classList.add("is-clicked");
+    };
+
+    const handlePointerUp = () => {
+      dot.classList.remove("is-clicked");
+      ring.classList.remove("is-clicked");
+    };
+
     window.addEventListener("pointermove", handleMove);
+    window.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("pointerup", handlePointerUp);
     document.addEventListener("mouseover", setActiveState);
     document.addEventListener("mouseout", setActiveState);
     rafId = window.requestAnimationFrame(animate);
 
     return () => {
       window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("pointerup", handlePointerUp);
       document.removeEventListener("mouseover", setActiveState);
       document.removeEventListener("mouseout", setActiveState);
       window.cancelAnimationFrame(rafId);

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -3,6 +3,8 @@ import { Github, Linkedin, Mail } from "lucide-react";
 const chips = ["Website", "Gráficos", "Vídeo", "3D"];
 
 export default function Footer() {
+  const currentYear = new Date().getFullYear();
+
   const handleSubmit = (event) => {
     event.preventDefault();
     const formData = new FormData(event.currentTarget);
@@ -32,39 +34,55 @@ export default function Footer() {
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-12">
         <div className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr]">
           <div className="rounded-3xl border border-white/10 bg-white/5 p-8">
-            <h2 className="text-2xl font-semibold">Connect with me</h2>
+            <h2 className="text-2xl font-semibold">Conecte-se comigo</h2>
             <p className="mt-2 text-sm text-white/60">
               Conte um pouco sobre seu projeto para criarmos algo único.
             </p>
             <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
               <div className="grid gap-4 sm:grid-cols-2">
+                <label className="sr-only" htmlFor="firstName">
+                  Nome
+                </label>
                 <input
+                  id="firstName"
                   type="text"
                   name="firstName"
                   placeholder="Nome"
                   required
-                  className="rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-white/80 placeholder:text-white/40"
+                  className="rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-white/80 placeholder:text-white/40 focus:border-cyan-200 focus:outline-none focus:ring-1 focus:ring-cyan-200"
                 />
+                <label className="sr-only" htmlFor="lastName">
+                  Sobrenome
+                </label>
                 <input
+                  id="lastName"
                   type="text"
                   name="lastName"
                   placeholder="Sobrenome"
-                  className="rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-white/80 placeholder:text-white/40"
+                  className="rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-white/80 placeholder:text-white/40 focus:border-cyan-200 focus:outline-none focus:ring-1 focus:ring-cyan-200"
                 />
               </div>
               <div className="grid gap-4 sm:grid-cols-2">
+                <label className="sr-only" htmlFor="email">
+                  Email
+                </label>
                 <input
+                  id="email"
                   type="email"
                   name="email"
                   placeholder="Email"
                   required
-                  className="rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-white/80 placeholder:text-white/40"
+                  className="rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-white/80 placeholder:text-white/40 focus:border-cyan-200 focus:outline-none focus:ring-1 focus:ring-cyan-200"
                 />
+                <label className="sr-only" htmlFor="phone">
+                  Telefone
+                </label>
                 <input
+                  id="phone"
                   type="tel"
                   name="phone"
                   placeholder="Telefone"
-                  className="rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-white/80 placeholder:text-white/40"
+                  className="rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-white/80 placeholder:text-white/40 focus:border-cyan-200 focus:outline-none focus:ring-1 focus:ring-cyan-200"
                 />
               </div>
               <div className="flex flex-wrap gap-3 text-xs uppercase tracking-[0.3em] text-white/60">
@@ -79,14 +97,16 @@ export default function Footer() {
               </div>
               <textarea
                 rows="4"
+                id="message"
                 name="message"
                 placeholder="Como posso ajudar?"
-                className="w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-white/80 placeholder:text-white/40"
+                required
+                className="w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-white/80 placeholder:text-white/40 focus:border-cyan-200 focus:outline-none focus:ring-1 focus:ring-cyan-200"
               />
               <button
                 type="submit"
                 data-cursor="large"
-                className="w-full rounded-full bg-white py-3 text-sm font-semibold uppercase tracking-[0.3em] text-black transition hover:bg-cyan-100"
+                className="w-full rounded-full bg-white py-3 text-sm font-semibold uppercase tracking-[0.3em] text-black transition hover:bg-cyan-100 hover:shadow-lg hover:shadow-cyan-500/20"
               >
                 Enviar
               </button>
@@ -99,7 +119,7 @@ export default function Footer() {
 
         <div className="flex flex-col items-center justify-between gap-6 border-t border-white/10 pt-8 text-center sm:flex-row">
           <p className="text-sm text-white/60">
-            © 2025 Guilherme Costa. Todos os direitos reservados.
+            © {currentYear} Guilherme Costa. Todos os direitos reservados.
           </p>
           <p className="text-sm text-white/60">Contato: contato@guilherme.dev</p>
           <div className="flex gap-4">
@@ -109,6 +129,7 @@ export default function Footer() {
               rel="noreferrer"
               data-cursor="large"
               className="text-white/70 transition hover:text-cyan-200"
+              aria-label="GitHub"
             >
               <Github size={20} />
             </a>
@@ -118,6 +139,7 @@ export default function Footer() {
               rel="noreferrer"
               data-cursor="large"
               className="text-white/70 transition hover:text-cyan-200"
+              aria-label="LinkedIn"
             >
               <Linkedin size={20} />
             </a>
@@ -125,6 +147,7 @@ export default function Footer() {
               href="mailto:contato@guilherme.dev"
               data-cursor="large"
               className="text-white/70 transition hover:text-cyan-200"
+              aria-label="Email"
             >
               <Mail size={20} />
             </a>

--- a/src/components/Hero/Hero.jsx
+++ b/src/components/Hero/Hero.jsx
@@ -1,4 +1,5 @@
 import { motion } from "framer-motion";
+import { ChevronDown } from "lucide-react";
 import { useEffect, useRef } from "react";
 
 export default function Hero() {
@@ -10,25 +11,37 @@ export default function Hero() {
       return undefined;
     }
 
-    let current = 0;
-    let target = 0;
+    let currentY = 0;
+    let targetY = 0;
+    let currentX = 0;
+    let targetX = 0;
     let rafId;
 
     const handleScroll = () => {
-      target = window.scrollY || 0;
+      targetY = window.scrollY || 0;
+    };
+
+    const handleMove = (event) => {
+      const offset = (event.clientX - window.innerWidth / 2) * 0.02;
+      targetX = offset;
     };
 
     const animate = () => {
-      current += (target - current) * 0.08;
-      element.style.transform = `translate3d(-50%, ${current * 0.15}px, 0)`;
+      currentY += (targetY - currentY) * 0.08;
+      currentX += (targetX - currentX) * 0.08;
+      element.style.transform = `translate3d(calc(-50% + ${currentX}px), ${
+        currentY * 0.15
+      }px, 0)`;
       rafId = window.requestAnimationFrame(animate);
     };
 
     window.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("mousemove", handleMove);
     rafId = window.requestAnimationFrame(animate);
 
     return () => {
       window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("mousemove", handleMove);
       window.cancelAnimationFrame(rafId);
     };
   }, []);
@@ -48,7 +61,7 @@ export default function Hero() {
         <motion.span
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8 }}
+          transition={{ duration: 0.8, ease: "easeOut" }}
           className="text-xs uppercase tracking-[0.5em] text-cyan-200/80"
         >
           Design em detalhes
@@ -57,38 +70,82 @@ export default function Hero() {
           <motion.h1
             initial={{ opacity: 0, y: 60 }}
             animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 1 }}
+            transition={{ duration: 1, delay: 0.2, ease: "easeOut" }}
             className="font-display text-[clamp(3rem,14vw,10rem)] font-bold text-white"
           >
             PORTFOLIO
           </motion.h1>
           <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-            <span className="font-display text-[clamp(4rem,16vw,11rem)] text-white/10">
+            <motion.span
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ duration: 1, delay: 0.5 }}
+              className="font-display text-[clamp(4rem,16vw,11rem)] text-white/10"
+            >
               G
-            </span>
+            </motion.span>
           </div>
         </div>
-        <p className="max-w-2xl text-sm text-white/70 md:text-base">
+        <motion.p
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8, delay: 0.4, ease: "easeOut" }}
+          className="max-w-2xl text-sm text-white/70 md:text-base"
+        >
           Transformo ideias em experiências digitais marcantes. Aqui você encontra a
           combinação de design, movimento e presença visual que destaca sua marca.
-        </p>
-        <div className="flex flex-wrap items-center justify-center gap-4">
-          <a
+        </motion.p>
+        <motion.div
+          initial="hidden"
+          animate="visible"
+          variants={{
+            visible: {
+              transition: { staggerChildren: 0.15, delayChildren: 0.6 },
+            },
+          }}
+          className="flex flex-wrap items-center justify-center gap-4"
+        >
+          <motion.a
             href="#portfolio"
             data-cursor="large"
             className="rounded-full border border-white/20 px-6 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:border-cyan-200/80 hover:text-cyan-200"
+            variants={{
+              hidden: { opacity: 0, y: 10 },
+              visible: { opacity: 1, y: 0 },
+            }}
           >
             Ver projetos
-          </a>
-          <a
+          </motion.a>
+          <motion.a
             href="#contato"
             data-cursor="large"
             className="rounded-full bg-white px-6 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-black transition hover:bg-cyan-100"
+            variants={{
+              hidden: { opacity: 0, y: 10 },
+              visible: { opacity: 1, y: 0 },
+            }}
           >
             Vamos conversar
-          </a>
-        </div>
-        <span className="font-signature text-3xl text-lime-300">Guilherme</span>
+          </motion.a>
+        </motion.div>
+        <motion.span
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8, delay: 0.9, ease: "easeOut" }}
+          className="font-signature text-3xl text-lime-300"
+        >
+          Guilherme
+        </motion.span>
+        <motion.a
+          href="#sobre"
+          aria-label="Ir para a próxima seção"
+          className="flex flex-col items-center gap-2 text-xs uppercase tracking-[0.4em] text-white/50"
+          animate={{ y: [0, 8, 0] }}
+          transition={{ duration: 1.8, repeat: Infinity, ease: "easeInOut" }}
+        >
+          Scroll
+          <ChevronDown className="h-4 w-4" />
+        </motion.a>
       </div>
     </section>
   );

--- a/src/components/Portfolio/Portfolio.jsx
+++ b/src/components/Portfolio/Portfolio.jsx
@@ -1,4 +1,5 @@
 import { motion } from "framer-motion";
+import { ArrowUpRight } from "lucide-react";
 
 const projetos = [
   {
@@ -36,21 +37,21 @@ export default function Portfolio() {
       <div className="mx-auto w-full max-w-6xl space-y-12">
         <div className="space-y-4 text-center">
           <span className="text-xs uppercase tracking-[0.4em] text-cyan-200/70">
-            Featured Websites
+            Projetos em destaque
           </span>
           <h2 className="text-3xl font-semibold md:text-4xl">
-            Impress, Engage, and Perform.
+            Impacto visual que converte.
           </h2>
           <p className="mx-auto max-w-2xl text-sm text-white/70 md:text-base">
             Seleção de projetos com foco em presença digital e acabamento visual
             premium. Cada card simula a estrutura do portfólio em destaque.
           </p>
           <a
-            href="#portfolio"
+            href="#contato"
             data-cursor="large"
             className="inline-flex items-center gap-2 text-xs uppercase tracking-[0.4em] text-cyan-200/70 transition hover:text-cyan-100"
           >
-            All Sites <span aria-hidden="true">→</span>
+            Vamos criar juntos <span aria-hidden="true">→</span>
           </a>
         </div>
 
@@ -60,20 +61,29 @@ export default function Portfolio() {
               key={projeto.nome}
               initial={{ opacity: 0, y: 40 }}
               whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: index * 0.1 }}
+              transition={{ duration: 0.5, delay: index * 0.12, ease: "easeOut" }}
               viewport={{ once: true }}
-              className="card-hover group relative overflow-hidden rounded-2xl border border-white/10 bg-white/5 transition hover:border-white/30"
+              className="card-hover group relative overflow-hidden rounded-2xl border border-white/10 bg-white/5 transition hover:border-white/30 hover:shadow-xl hover:shadow-cyan-500/10"
             >
-              <img
+              <motion.img
                 src={projeto.imagem}
                 alt={projeto.nome}
+                loading="lazy"
+                initial={{ y: 14 }}
+                whileInView={{ y: 0 }}
+                transition={{ duration: 0.6, ease: "easeOut" }}
                 className="h-56 w-full object-cover transition duration-500 group-hover:scale-105"
               />
               <div className="space-y-2 p-4">
                 <p className="text-xs uppercase tracking-[0.3em] text-white/40">
                   2025
                 </p>
-                <h3 className="text-lg font-semibold">{projeto.nome}</h3>
+                <div className="flex items-center justify-between gap-3">
+                  <h3 className="text-lg font-semibold">{projeto.nome}</h3>
+                  <span className="flex h-8 w-8 items-center justify-center rounded-full border border-white/10 text-white/60 opacity-0 transition group-hover:opacity-100">
+                    <ArrowUpRight className="h-4 w-4" />
+                  </span>
+                </div>
                 <p className="text-sm text-white/60">{projeto.descricao}</p>
                 <span className="inline-flex text-xs uppercase tracking-[0.3em] text-white/50">
                   {projeto.status}

--- a/src/components/Services/Services.jsx
+++ b/src/components/Services/Services.jsx
@@ -1,4 +1,5 @@
 import { motion } from "framer-motion";
+import { Box, Monitor, Palette, Video } from "lucide-react";
 
 const services = [
   "Website Design",
@@ -11,18 +12,22 @@ const services = [
 const serviceCards = [
   {
     title: "Website Design",
+    icon: Monitor,
     items: ["Landing Pages", "E-commerce", "Portfolio", "UI/UX Design"],
   },
   {
     title: "Graphic Design",
+    icon: Palette,
     items: ["Posters", "Banners", "Brand Guides", "Packaging"],
   },
   {
     title: "Video Editing",
+    icon: Video,
     items: ["Promos", "Corporate", "Social Clips", "Motion"],
   },
   {
     title: "3D Modeling",
+    icon: Box,
     items: ["Product Design", "Visualization", "Interior", "Motion 3D"],
   },
 ];
@@ -40,7 +45,7 @@ export default function Services() {
           viewport={{ once: true }}
           className="text-center"
         >
-          <h2 className="section-title text-white">SERVICES</h2>
+          <h2 className="section-title text-white">SERVIÇOS</h2>
           <p className="mx-auto mt-4 max-w-2xl text-sm text-white/60 md:text-base">
             Estruturo soluções completas para web, branding e mídia digital,
             sempre com visual premium e foco em conversão.
@@ -52,7 +57,7 @@ export default function Services() {
             {services.map((service) => `${service} · `).join(" ")}
           </span>
         </div>
-        <div className="grid gap-6 md:grid-cols-2">
+        <div className="grid gap-6 md:grid-cols-2 xl:gap-8">
           {serviceCards.map((card, index) => (
             <motion.div
               key={card.title}
@@ -60,9 +65,14 @@ export default function Services() {
               whileInView={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: index * 0.1 }}
               viewport={{ once: true }}
-              className="card-hover rounded-2xl border border-white/10 bg-white/5 p-6"
+              className="card-hover rounded-2xl border border-white/10 bg-white/5 p-6 md:p-8"
             >
-              <h3 className="text-lg font-semibold">{card.title}</h3>
+              <div className="flex items-center gap-3">
+                <span className="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 text-cyan-200">
+                  <card.icon className="h-5 w-5" />
+                </span>
+                <h3 className="text-lg font-semibold">{card.title}</h3>
+              </div>
               <ul className="mt-4 space-y-2 text-sm text-white/60">
                 {card.items.map((item) => (
                   <li key={item}>• {item}</li>
@@ -73,7 +83,7 @@ export default function Services() {
         </div>
         <div className="text-center">
           <p className="text-xs uppercase tracking-[0.4em] text-white/40">
-            Worked With
+            Parcerias
           </p>
           <div className="mt-6 flex flex-wrap items-center justify-center gap-4">
             {partners.map((partner) => (

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -10,6 +10,17 @@ body {
   scroll-behavior: smooth;
 }
 
+@media (pointer: fine) {
+  body {
+    cursor: none;
+  }
+}
+
+:focus-visible {
+  outline: 2px solid rgba(125, 211, 252, 0.9);
+  outline-offset: 3px;
+}
+
 .font-display {
   font-family: "Bebas Neue", "Space Grotesk", sans-serif;
   letter-spacing: 0.04em;
@@ -48,6 +59,10 @@ body {
   padding-right: 3rem;
   opacity: 0.5;
   animation: marquee 14s linear infinite;
+}
+
+.service-marquee:hover span {
+  animation-play-state: paused;
 }
 
 .highlight-word {
@@ -91,7 +106,7 @@ body {
   left: 0;
   pointer-events: none;
   z-index: 60;
-  transition: opacity 0.2s ease;
+  transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
 .cursor-dot {
@@ -122,6 +137,21 @@ body {
   height: 52px;
   border-color: rgba(125, 211, 252, 0.9);
   box-shadow: 0 0 20px rgba(56, 189, 248, 0.45);
+}
+
+.cursor-dot.is-clicked {
+  transform: scale(0.8);
+  opacity: 0.6;
+}
+
+.cursor-ring.is-clicked {
+  transform: scale(0.85);
+  border-color: rgba(255, 255, 255, 0.7);
+}
+
+.cursor-dot.is-hidden,
+.cursor-ring.is-hidden {
+  opacity: 0;
 }
 
 
@@ -161,5 +191,15 @@ body {
   }
   50% {
     transform: translateY(-18px) rotate(2deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .service-marquee span {
+    animation: none;
+  }
+
+  .orb {
+    animation: none;
   }
 }


### PR DESCRIPTION
### Motivation
- Make the site feel more polished and fluid by adding mobile navigation, refined entrance animations, and subtle parallax to match a high-impact visual portfolio standard.
- Improve mobile usability and discoverability by providing an overlay hamburger menu and visible nav state for the active section.
- Increase accessibility and UX by adding focus-visible styles, form labels, and respecting reduced-motion preferences.
- Provide clearer interaction feedback via a smarter custom cursor and improved hover/press states.

### Description
- Added an animated mobile overlay menu with Framer Motion, active-section highlighting via `IntersectionObserver`, scroll-aware navbar styling, and body scroll lock while the menu is open (`src/components/Navbar/Navbar.jsx`).
- Refined hero sequencing and motion (staggered timings, eased transitions) and enhanced the glow with mouse-driven parallax plus a persistent scroll cue (`src/components/Hero/Hero.jsx`).
- Improved Services and Portfolio visuals with icons, marquee pause-on-hover, lazy-loaded/project image motion, enhanced hover feedback, and updated copy/CTAs (`src/components/Services/Services.jsx`, `src/components/Portfolio/Portfolio.jsx`).
- Made the cursor smarter (hide in inputs, click state), added accessible form labels, dynamic year, improved form focus styles, and global CSS updates including `cursor: none` for fine pointers, `:focus-visible`, and `prefers-reduced-motion` fallbacks (`src/components/CursorFollower/CursorFollower.jsx`, `src/components/Footer/Footer.jsx`, `src/styles/globals.css`).

### Testing
- Started the dev server with `npm run dev` and confirmed Vite reported the site as ready, which succeeded. 
- Captured a headless browser screenshot of the homepage using Playwright to validate visual changes, which completed and produced an artifact. 
- No unit tests were added or run as part of this PR. 
- Manual verification steps (visual smoke) were performed via the served site and screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ebc3796748331b8f4f3355dc7c77d)